### PR TITLE
Add support for sudo

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -23,6 +23,10 @@ var (
 	// Masked units can only be unmasked, but something else was attempted
 	// Unmask the unit before enabling or disabling it
 	ErrMasked = errors.New("unit masked")
+	// ErrNoSudo is returned when sudo is needed and not installed.
+	ErrNoSudo = errors.New("sudo not in $PATH")
+	// ErrSudoPasswordEntryFail indicates that a password was required for sudo but this failed.
+	ErrSudoPasswordEntryFail = errors.New("sudo password entry failed. Use passwordless sudo or either the SudoPass or SudoAskPass option")
 	// Make sure systemctl is in the PATH before calling again
 	ErrNotInstalled = errors.New("systemctl not in $PATH")
 	// A unit was expected to be running but was found inactive

--- a/helpers.go
+++ b/helpers.go
@@ -60,10 +60,7 @@ func GetPID(ctx context.Context, unit string, opts Options) (int, error) {
 
 func GetSocketsForServiceUnit(ctx context.Context, unit string, opts Options) ([]string, error) {
 	args := []string{"list-sockets", "--all", "--no-legend", "--no-pager"}
-	if opts.UserMode {
-		args = append(args, "--user")
-	}
-	stdout, _, _, err := execute(ctx, args)
+	stdout, _, _, err := execute(ctx, args, opts)
 	if err != nil {
 		return []string{}, err
 	}
@@ -85,10 +82,7 @@ func GetSocketsForServiceUnit(ctx context.Context, unit string, opts Options) ([
 
 func GetUnits(ctx context.Context, opts Options) ([]Unit, error) {
 	args := []string{"list-units", "--all", "--no-legend", "--full", "--no-pager"}
-	if opts.UserMode {
-		args = append(args, "--user")
-	}
-	stdout, stderr, _, err := execute(ctx, args)
+	stdout, stderr, _, err := execute(ctx, args, opts)
 	if err != nil {
 		return []Unit{}, errors.Join(err, filterErr(stderr))
 	}
@@ -113,10 +107,7 @@ func GetUnits(ctx context.Context, opts Options) ([]Unit, error) {
 
 func GetMaskedUnits(ctx context.Context, opts Options) ([]string, error) {
 	args := []string{"list-unit-files", "--state=masked"}
-	if opts.UserMode {
-		args = append(args, "--user")
-	}
-	stdout, stderr, _, err := execute(ctx, args)
+	stdout, stderr, _, err := execute(ctx, args, opts)
 	if err != nil {
 		return []string{}, errors.Join(err, filterErr(stderr))
 	}

--- a/structs.go
+++ b/structs.go
@@ -4,6 +4,17 @@ package systemctl
 
 type Options struct {
 	UserMode bool
+	// When true, sudo is used to run the systemctl commands.
+	Sudo bool
+	// Specify the sudo password.
+	// Only applies if Sudo is true.
+	// Optional if passwordless sudo is enabled or SudoAskPass is used.
+	// Mutually exclusive with SudoAskPass.
+	SudoPass string
+	// When true, the --askpass sudo flag is used. See man sudo.
+	// Requires Sudo: true.
+	// Mutually exclusive with SudoPass.
+	SudoAskPass bool
 }
 
 type Unit struct {

--- a/systemctl.go
+++ b/systemctl.go
@@ -17,11 +17,8 @@ import (
 // reloaded, all sockets systemd listens on behalf of user configuration will
 // stay accessible.
 func DaemonReload(ctx context.Context, opts Options) error {
-	args := []string{"daemon-reload", "--system"}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	_, _, _, err := execute(ctx, args)
+	args := []string{"daemon-reload"}
+	_, _, _, err := execute(ctx, args, opts)
 	return err
 }
 
@@ -31,11 +28,8 @@ func DaemonReload(ctx context.Context, opts Options) error {
 // the unit configuration directory, then recreates the symlink to the unit again,
 // atomically. Can be used to change the symlink target.
 func Reenable(ctx context.Context, unit string, opts Options) error {
-	args := []string{"reenable", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	_, _, _, err := execute(ctx, args)
+	args := []string{"reenable", unit}
+	_, _, _, err := execute(ctx, args, opts)
 	return err
 }
 
@@ -45,11 +39,8 @@ func Reenable(ctx context.Context, unit string, opts Options) error {
 // the unit configuration directory, and hence undoes any changes made by
 // enable or link.
 func Disable(ctx context.Context, unit string, opts Options) error {
-	args := []string{"disable", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	_, _, _, err := execute(ctx, args)
+	args := []string{"disable", unit}
+	_, _, _, err := execute(ctx, args, opts)
 	return err
 }
 
@@ -60,11 +51,8 @@ func Disable(ctx context.Context, unit string, opts Options) error {
 // manager configuration is reloaded (in a way equivalent to daemon-reload),
 // in order to ensure the changes are taken into account immediately.
 func Enable(ctx context.Context, unit string, opts Options) error {
-	args := []string{"enable", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	_, _, _, err := execute(ctx, args)
+	args := []string{"enable", unit}
+	_, _, _, err := execute(ctx, args, opts)
 	return err
 }
 
@@ -73,11 +61,8 @@ func Enable(ctx context.Context, unit string, opts Options) error {
 // Returns true if the unit is active, false if inactive or failed.
 // Also returns false in an error case.
 func IsActive(ctx context.Context, unit string, opts Options) (bool, error) {
-	args := []string{"is-active", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	stdout, _, _, err := execute(ctx, args)
+	args := []string{"is-active", unit}
+	stdout, _, _, err := execute(ctx, args, opts)
 	stdout = strings.TrimSuffix(stdout, "\n")
 	switch stdout {
 	case "inactive":
@@ -103,11 +88,8 @@ func IsActive(ctx context.Context, unit string, opts Options) (bool, error) {
 // See https://www.freedesktop.org/software/systemd/man/systemctl.html#is-enabled%20UNIT%E2%80%A6
 // for more information
 func IsEnabled(ctx context.Context, unit string, opts Options) (bool, error) {
-	args := []string{"is-enabled", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	stdout, _, _, err := execute(ctx, args)
+	args := []string{"is-enabled", unit}
+	stdout, _, _, err := execute(ctx, args, opts)
 	stdout = strings.TrimSuffix(stdout, "\n")
 	switch stdout {
 	case "enabled":
@@ -143,11 +125,8 @@ func IsEnabled(ctx context.Context, unit string, opts Options) (bool, error) {
 
 // Check whether any of the specified units are in a "failed" state.
 func IsFailed(ctx context.Context, unit string, opts Options) (bool, error) {
-	args := []string{"is-failed", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	stdout, _, _, err := execute(ctx, args)
+	args := []string{"is-failed", unit}
+	stdout, _, _, err := execute(ctx, args, opts)
 	if matched, _ := regexp.MatchString(`inactive`, stdout); matched {
 		return false, nil
 	} else if matched, _ := regexp.MatchString(`active`, stdout); matched {
@@ -165,33 +144,24 @@ func IsFailed(ctx context.Context, unit string, opts Options) (bool, error) {
 // continue masking anyway. Calling Mask on a non-existing masked unit does not
 // return an error. Similarly, see Unmask.
 func Mask(ctx context.Context, unit string, opts Options) error {
-	args := []string{"mask", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	_, _, _, err := execute(ctx, args)
+	args := []string{"mask", unit}
+	_, _, _, err := execute(ctx, args, opts)
 	return err
 }
 
 // Stop and then start one or more units specified on the command line.
 // If the units are not running yet, they will be started.
 func Restart(ctx context.Context, unit string, opts Options) error {
-	args := []string{"restart", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	_, _, _, err := execute(ctx, args)
+	args := []string{"restart", unit}
+	_, _, _, err := execute(ctx, args, opts)
 	return err
 }
 
 // Show a selected property of a unit. Accepted properties are predefined in the
 // properties subpackage to guarantee properties are valid and assist code-completion.
 func Show(ctx context.Context, unit string, property properties.Property, opts Options) (string, error) {
-	args := []string{"show", "--system", unit, "--property", string(property)}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	stdout, _, _, err := execute(ctx, args)
+	args := []string{"show", unit, "--property", string(property)}
+	stdout, _, _, err := execute(ctx, args, opts)
 	stdout = strings.TrimPrefix(stdout, string(property)+"=")
 	stdout = strings.TrimSuffix(stdout, "\n")
 	return stdout, err
@@ -199,11 +169,8 @@ func Show(ctx context.Context, unit string, property properties.Property, opts O
 
 // Start (activate) a given unit
 func Start(ctx context.Context, unit string, opts Options) error {
-	args := []string{"start", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	_, _, _, err := execute(ctx, args)
+	args := []string{"start", unit}
+	_, _, _, err := execute(ctx, args, opts)
 	return err
 }
 
@@ -213,21 +180,15 @@ func Start(ctx context.Context, unit string, opts Options) error {
 // Generally, it makes more sense to programatically retrieve the properties
 // using Show, but this command is provided for the sake of completeness
 func Status(ctx context.Context, unit string, opts Options) (string, error) {
-	args := []string{"status", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	stdout, _, _, err := execute(ctx, args)
+	args := []string{"status", unit}
+	stdout, _, _, err := execute(ctx, args, opts)
 	return stdout, err
 }
 
 // Stop (deactivate) a given unit
 func Stop(ctx context.Context, unit string, opts Options) error {
-	args := []string{"stop", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	_, _, _, err := execute(ctx, args)
+	args := []string{"stop", unit}
+	_, _, _, err := execute(ctx, args, opts)
 	return err
 }
 
@@ -239,10 +200,7 @@ func Stop(ctx context.Context, unit string, opts Options) error {
 // If the unit doesn't exist but it's masked anyway, no error will be
 // returned. Gross, I know. Take it up with Poettering.
 func Unmask(ctx context.Context, unit string, opts Options) error {
-	args := []string{"unmask", "--system", unit}
-	if opts.UserMode {
-		args[1] = "--user"
-	}
-	_, _, _, err := execute(ctx, args)
+	args := []string{"unmask", unit}
+	_, _, _, err := execute(ctx, args, opts)
 	return err
 }

--- a/util.go
+++ b/util.go
@@ -20,7 +20,7 @@ func init() {
 	systemctl = path
 }
 
-func execute(ctx context.Context, args []string) (string, string, int, error) {
+func execute(ctx context.Context, args []string, opts Options) (string, string, int, error) {
 	var (
 		err      error
 		stderr   bytes.Buffer
@@ -33,6 +33,11 @@ func execute(ctx context.Context, args []string) (string, string, int, error) {
 	if systemctl == "" {
 		return "", "", 1, ErrNotInstalled
 	}
+
+	if opts.UserMode {
+		args = append(args, "--user")
+	}
+
 	cmd := exec.CommandContext(ctx, systemctl, args...)
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/util.go
+++ b/util.go
@@ -12,11 +12,13 @@ import (
 )
 
 var systemctl string
+var sudoPath string
 
 const killed = 130
 
 func init() {
 	path, _ := exec.LookPath("systemctl")
+	sudoPath, _ = exec.LookPath("sudo")
 	systemctl = path
 }
 
@@ -38,7 +40,29 @@ func execute(ctx context.Context, args []string, opts Options) (string, string, 
 		args = append(args, "--user")
 	}
 
-	cmd := exec.CommandContext(ctx, systemctl, args...)
+	var cmd *exec.Cmd
+	if opts.Sudo {
+		if sudoPath == "" {
+			return "", "", 1, ErrNoSudo
+		}
+
+		var sudoArgs []string
+		if opts.SudoAskPass {
+			sudoArgs = append(sudoArgs, "--askpass")
+		}
+		if opts.SudoPass != "" {
+			sudoArgs = append(sudoArgs, "--stdin")
+		}
+		sudoArgs = append(sudoArgs, systemctl)
+
+		args = append(sudoArgs, args...)
+		cmd = exec.CommandContext(ctx, "sudo", args...)
+		if opts.SudoPass != "" {
+			cmd.Stdin = strings.NewReader(opts.SudoPass)
+		}
+	} else {
+		cmd = exec.CommandContext(ctx, systemctl, args...)
+	}
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err = cmd.Run()
@@ -59,6 +83,8 @@ func execute(ctx context.Context, args []string, opts Options) (string, string, 
 
 func filterErr(stderr string) error {
 	switch {
+	case strings.Contains(stderr, "sudo: a terminal is required to read the password"):
+		return ErrSudoPasswordEntryFail
 	case strings.Contains(stderr, `does not exist`):
 		return errors.Join(ErrDoesNotExist, fmt.Errorf("stderr: %s", stderr))
 	case strings.Contains(stderr, `not found.`):


### PR DESCRIPTION
This PR adds support for sudo usage in the following ways:

1. Passwordless sudo, with `Sudo: true`
2. Password protected sudo where the password is passed directly, with `Sudo: true, SudoPass: "passhere"`
3. Password protected sudo with an external password helper, with  `Sudo: true, SudoAskPass: true`

I've also moved some duplicate code to the execute function.
