### PR TITLE
Fix build lines conflict with go toolchain version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/taigrr/systemctl
 
-go 1.12
+go 1.18


### PR DESCRIPTION
21fce7918ea9bdec84a7d6ce0bfbd95a4d945119 adds build tags, however, these specific tags are not supported in the go version set in go.mod (1.12). See <https://go.dev/doc/go1.17#build-lines> and <https://go.dev/doc/go1.18#go-build-lines>.

I've updated the toolchain version in go.mod to 1.18. If you would like to maintain 1.12 compatibility, the older `// build+` lines are needed.