### PR TITLE
chore: update Go 1.26.2, document all helpers, consistent arg construction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.26"]
+        go-version: ["1.26", "1.26.2"]
     steps:
       - uses: actions/checkout@v4
 
@@ -39,7 +39,7 @@ jobs:
         run: sudo go test -race -coverprofile=coverage-root.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.26'
+        if: matrix.go-version == '1.26.2'
         uses: codecov/codecov-action@v5
         with:
           files: coverage-user.out,coverage-root.out

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ If your system isn't running (or targeting another system running) `systemctl`, 
 - [x] Get current memory in bytes (`MemoryCurrent`) as an int
 - [x] Get the PID of the main process (`MainPID`) as an int
 - [x] Get the restart count of a unit (`NRestarts`) as an int
+- [x] List all loaded units and their states (`list-units`)
+- [x] List masked units (`list-unit-files --state=masked`)
+- [x] Get sockets associated with a service unit (`list-sockets`)
+- [x] Check if a unit is masked
+- [x] Check if a unit is running (sub-state)
+- [x] Check if systemd is the init system (`/proc/1/comm`)
+- [x] Validate unit name suffixes against known systemd unit types
 
 
 ## Useful errors
@@ -55,7 +62,6 @@ package main
 
 import (
     "context"
-    "fmt"
     "log"
     "time"
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/taigrr/systemctl
 
-go 1.26.1
+go 1.26.2

--- a/helpers.go
+++ b/helpers.go
@@ -74,10 +74,7 @@ func GetPID(ctx context.Context, unit string, opts Options) (int, error) {
 
 // GetSocketsForServiceUnit returns the socket units associated with a given service unit.
 func GetSocketsForServiceUnit(ctx context.Context, unit string, opts Options) ([]string, error) {
-	args := []string{"list-sockets", "--all", "--no-legend", "--no-pager"}
-	if opts.UserMode {
-		args = append(args, "--user")
-	}
+	args := prepareArgs("list-sockets", opts, "--all", "--no-legend", "--no-pager")
 	stdout, _, _, err := execute(ctx, args)
 	if err != nil {
 		return []string{}, err
@@ -100,10 +97,7 @@ func GetSocketsForServiceUnit(ctx context.Context, unit string, opts Options) ([
 
 // GetUnits returns a list of all loaded units and their states.
 func GetUnits(ctx context.Context, opts Options) ([]Unit, error) {
-	args := []string{"list-units", "--all", "--no-legend", "--full", "--no-pager"}
-	if opts.UserMode {
-		args = append(args, "--user")
-	}
+	args := prepareArgs("list-units", opts, "--all", "--no-legend", "--full", "--no-pager")
 	stdout, stderr, _, err := execute(ctx, args)
 	if err != nil {
 		return []Unit{}, errors.Join(err, filterErr(stderr))
@@ -129,10 +123,7 @@ func GetUnits(ctx context.Context, opts Options) ([]Unit, error) {
 
 // GetMaskedUnits returns a list of all masked unit names.
 func GetMaskedUnits(ctx context.Context, opts Options) ([]string, error) {
-	args := []string{"list-unit-files", "--state=masked"}
-	if opts.UserMode {
-		args = append(args, "--user")
-	}
+	args := prepareArgs("list-unit-files", opts, "--state=masked")
 	stdout, stderr, _, err := execute(ctx, args)
 	if err != nil {
 		return []string{}, errors.Join(err, filterErr(stderr))


### PR DESCRIPTION
## Changes

- **Go version bump**: 1.26.1 → 1.26.2
- **README**: Document all helper functions that were missing from the feature list:
  - `GetUnits` — list all loaded units and their states
  - `GetMaskedUnits` — list masked units
  - `GetSocketsForServiceUnit` — get sockets for a service
  - `IsMasked` — check if a unit is masked
  - `IsRunning` — check if a unit's sub-state is running
  - `IsSystemd` — detect if systemd is the init system
  - `HasValidUnitSuffix` — validate unit name suffixes
- **README**: Remove unused `fmt` import from example code
- **Refactor**: `GetSocketsForServiceUnit`, `GetUnits`, and `GetMaskedUnits` now use `prepareArgs` instead of manually constructing args with user/system mode checks. This ensures consistent `--system`/`--user` flag handling across all functions.
- **CI**: Add Go 1.26.2 to test matrix, run coverage upload on latest version